### PR TITLE
fix: convert section H1 tags to H2 for proper heading hierarchy

### DIFF
--- a/website/src/components/HomepageContent/index.js
+++ b/website/src/components/HomepageContent/index.js
@@ -29,7 +29,7 @@ export default function HomepageContent() {
                     className={styles.sectionHeader}
                     style={{ marginBottom: '15px', marginTop: '15px' }}
                 >
-                    <h1>AboutCode Projects Overview</h1>
+                    <h2>AboutCode Projects Overview</h2>
                 </div>
 
                 <div className={styles.sectionIntro}>
@@ -44,7 +44,7 @@ export default function HomepageContent() {
                     className={styles.sectionHeader}
                     style={{ marginBottom: '15px', marginTop: '30px' }}
                 >
-                    <h1>Supporters</h1>
+                    <h2>Supporters</h2>
                 </div>
                 <div className={styles.sectionIntro}>
                     <Supporters />


### PR DESCRIPTION
Fixes aboutcode-org/aboutcode#227

## Changes
- Converted "AboutCode Projects Overview" from H1 to H2
- Converted "Supporters" from H1 to H2
- Ensures single H1 per page for accessibility compliance

## Impact
- ✅ WCAG 2.1 compliant (Success Criterion 1.3.1)
- ✅ Improved SEO (single primary heading)
- ✅ Better screen reader navigation
- ✅ Proper semantic HTML structure

## Verification
- [x] Built successfully with npm
- [x] Tested locally at http://localhost:3000/www.aboutcode.org/
- [x] Verified single H1 tag via DevTools JavaScript
- [x] Confirmed proper heading hierarchy (H1 → H2 → H3)

## Testing Results
JavaScript verification confirmed exactly **1 H1 tag** on the homepage:
- H1: "Welcome to AboutCode.org" (primary heading)
- H2: "AboutCode Projects Overview" (converted from H1)
- H2: "Supporters" (converted from H1)