### PR TITLE
Modify upload-pages-artifact pinned version

### DIFF
--- a/.github/workflows/a-b-deploy.yml
+++ b/.github/workflows/a-b-deploy.yml
@@ -89,7 +89,7 @@ jobs:
           path: build
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b  # v4.0.0
         with:
           path: build
 


### PR DESCRIPTION
Of our 8 pinned actions in 2 `.yml` files, one of them (`actions/upload-pages-artifact v3.0.1`) has an `action.yml` file that calls an unpinned action -- `actions/upload-artifact@v4`, the apparent cause of the failed build.  https://github.com/actions/upload-pages-artifact/blob/v3.0.1/action.yml.  I've pinned `actions/upload-pages-artifact v4.0.0` instead, because it changed that unpinned dependency to a pinned SHA1 -- `actions/upload-artifact v4.6.2` (which we also use).