### PR TITLE
Add an A-B build-only workflow file

### DIFF
--- a/.github/workflows/a-b-build-only.yml
+++ b/.github/workflows/a-b-build-only.yml
@@ -1,0 +1,51 @@
+name: Build Docusaurus Site (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Build target (affects baseUrl config)"
+        required: true
+        default: "dreamhost"
+        type: choice
+        options:
+          - dreamhost
+          - gh
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install dependencies
+        run: |
+          cd website
+          npm ci
+
+      - name: Build Docusaurus site
+        env:
+          DEPLOY_TARGET: ${{ inputs.target }}
+        run: |
+          cd website
+          npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: docusaurus-build
+          path: website/build
+          # JMH -- TBD:
+          # retention-days: 7


### PR DESCRIPTION
For those occasions when a full build-and-deploy is not what you need.