### PR TITLE
Editorial updates for consistency/clarity

### DIFF
--- a/website/src/components/CapabilitiesGrid/index.js
+++ b/website/src/components/CapabilitiesGrid/index.js
@@ -6,27 +6,27 @@ const capabilities = [
     {
         title: 'License Detection',
         description: 'Detect licenses in any codebase, whether open source, or proprietary; in source code and binaries. Powers dozens of open source and commercial SCA tools.',
-        link: '/docs/getting_started/license-compliance/',
+        link: '/docs/getting_started/license-compliance/#identify-licenses-for-software-and-for-data',
     },
     {
         title: 'Code Origin Matching',
         description: 'Identify code origin at package, file, and snippet level using PurlDB fingerprints and matching pipelines.',
-        link: '/docs/getting_started/software-identification/',
+        link: '/docs/getting_started/software-identification/#match-binaries-to-source',
     },
     {
         title: 'Binary Analysis',
         description: 'Match deployed binaries, containers, and firmware back to source packages. Analyze ELFs, PEs, Mach-Os, and archives.',
-        link: '/docs/getting_started/software-identification/',
+        link: '/docs/getting_started/software-identification/#match-binaries-to-source',
     },
     {
         title: 'Dependency Management',
         description: 'Resolve direct and transitive dependencies across package ecosystems with ScanCode pipelines and dedicated inspectors.',
-        link: '/docs/getting_started/software-identification/',
+        link: '/docs/getting_started/software-identification/#identify-software-dependencies',
     },
     {
         title: 'Vulnerability Management',
         description: 'Aggregate vulnerability data, map to affected packages, identify fixes, and score exploitability and risk for triage.',
-        link: '/docs/getting_started/software-security/',
+        link: '/docs/getting_started/software-security/#manage-risk-with-aggregated-vulnerability-data',
     },
     {
         title: 'SBOMs and Compliance',

--- a/website/src/components/EcosystemGrid/index.js
+++ b/website/src/components/EcosystemGrid/index.js
@@ -254,16 +254,16 @@ export default function EcosystemGrid() {
         <div className={styles.gridWrapper}>
             <GridSection
                 id="licensing"
-                title="License"
+                title="Licenses"
                 items={licenses}
-                header_link={{ label: 'Get started with compliance', url: '/docs/getting_started/license-compliance/' }}
+                header_link={{ label: 'Get started with license compliance', url: '/docs/getting_started/license-compliance/' }}
                 intro={<p>AboutCode tracks over 2,500+ curated licenses across 12 categories. Browse all <a href="https://scancode-licensedb.aboutcode.org" target="_blank" rel="noopener noreferrer">2,500+ licenses</a> in the LicenseDB. Industry-leading license detection is backed by <a href="https://github.com/aboutcode-org/scancode-toolkit/tree/develop/src/licensedcode/data/rules" target="_blank" rel="noopener noreferrer">over 35,000 license notices</a> used as detection rules.</p>}
             />
             <GridSection
                 id="vuln-sources"
                 title="Software vulnerabilities"
                 items={vulnerability_sources}
-                header_link={{ label: 'Get started with security', url: '/docs/getting_started/software-security/' }}
+                header_link={{ label: 'Get started with software security', url: '/docs/getting_started/software-security/' }}
                 intro={<p>AboutCode collects, correlates, and improves vulnerabilities from multiple advisory data sources, privileging upstream data. </p>}
             />
             <GridSection
@@ -305,7 +305,7 @@ export default function EcosystemGrid() {
                 id="vuln-reference-data"
                 title="Vulnerability severity and other reference data"
                 items={vulnerability_reference_data}
-                header_link={{ label: 'Get started with security', url: '/docs/getting_started/software-security/' }}
+                header_link={{ label: 'Get started with software security', url: '/docs/getting_started/software-security/' }}
                 intro={<p>AboutCode imports vulnerability reference data in key industry formats, mapping these to PURL. </p>}
             />
         </div>

--- a/website/src/components/HomepageContent/index.js
+++ b/website/src/components/HomepageContent/index.js
@@ -38,7 +38,7 @@ export default function HomepageContent() {
                     className={styles.sectionHeader}
                     style={{ marginBottom: '15px', marginTop: '15px' }}
                 >
-                    <h2>Main capabilities</h2>
+                    <h2>Capabilities</h2>
                 </div>
                 <div className={styles.sectionIntro}>
                     <p>AboutCode provides modular building blocks for software composition analysis,

--- a/website/src/data/projects-all.js
+++ b/website/src/data/projects-all.js
@@ -11,7 +11,7 @@ import {
 export const allProjectSources = [
     {
         id: 'application-projects',
-        title: 'Apps for the software supply chains',
+        title: 'Apps for software supply chains',
         data: [...projectsApplication, clearlyDefinedProject],
     },
     {


### PR DESCRIPTION
Home page
- Changed "Main Capabilities" heading to "Capabilities"
- Capabiliities - refined links to more specific heading level topics
- Changed "License - Get started with compliance..." heading to "Licenses - Get started with license compliance..."
- Changed "Security - Get started with security..." heading to "Software security - Get started with software security..."
- For "Vulnerability severity and other reference data" changed "Get started with security..." to "Get started with software security..." 
Projects page
- Changed "Apps for the software supply chains" to "Apps for software supply chains"